### PR TITLE
provide a default testing case to run the docker image for a small E.…

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,23 @@ Peregrine is designed to run on single compute node. It does not need a grid
 computing job scheduling system. It uses Pypeflow to coordinate multiple
 concurrent processes.  
 
-Here is the usage for `pg_run.py` which starts the workflow for assembling a
-genome from input `fasta`, `fastq`, `fasta.gz` or `fastq.gz` files. 
+After revsion 0.1.5.3, You can test a small assembly using simulated E. Coli 
+reads with Docker:
+
+```
+# please substitue $PWD and $IMAGETAG with proper values
+docker run -it --rm -v $PWD:/wd cschin/peregrine:$IMAGETAG test
+```
+
+The assembly results are in `$PWD/ecoli_test_results/`. The testing case will
+download an E. Coli reference and generate simulated reads. After the assembly
+is done, it also installs `nucmer` to run `dandiff` comparing the assembled 
+contigs with the original E. coli reference. You can check the ouput by using 
+`cat $PWD/ecoli_test_results/out.report` command.
+
+Here is the general usage for `pg_run.py` which starts the workflow for 
+assembling a genome from input `fasta`, `fastq`, `fasta.gz` or 
+`fastq.gz` files. 
 
 ```
 Usage:

--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 . /opt/conda/etc/profile.d/conda.sh
 conda activate peregrine
-pg_run.py $@
+if [ $1 == "test" ]; then 
+  cd /opt/test
+  bash /opt/test/run_test.sh
+else  
+  pg_run.py $@
+fi

--- a/docker/test/Makefile
+++ b/docker/test/Makefile
@@ -10,24 +10,10 @@ simreads: K12MG1655.fa
 
 reads_0.fa: simreads
 
-test:
-	rm -rf ./wd ./logs
-	/usr/bin/time ./run_test.sh > all.log 2>&1;  mkdir -p logs;  mv *.log logs 
-
 test-pypeflow:
 	rm -rf ./wd-pf
 	find ${PWD}/reads/ -name "reads_*.fa" > seq_dataset.lst
 	/usr/bin/time pg_run.py asm seq_dataset.lst 12 4 8 4 1 1 1 1 1 --with-consensus --output ./wd-pf
-
-test-pypeflow-with-L0:
-	rm -rf ./wd-pf
-	find ${PWD}/reads/ -name "reads_*.fa" > seq_dataset.lst
-	/usr/bin/time pg_run.py asm seq_dataset.lst 12 4 8 4 1 1 1 1 1 --with-L0-index --with-consensus --output ./wd-pf
-
-test-pypeflow-l1:
-	rm -rf ./wd-pf-l1
-	find ${PWD}/reads/ -name "reads_*.fa" > seq_dataset.lst
-	/usr/bin/time pg_run.py asm seq_dataset.lst 12 4 8 4 1 1 1 1 1 --shimmer-r 24 --with-consensus --shimmer-l 1 --output ./wd-pf-l1
 
 clean:
 	rm -rf ./wd/ ./logs/ ./reads/ seq_dataset.lst

--- a/docker/test/Makefile
+++ b/docker/test/Makefile
@@ -19,5 +19,15 @@ test-pypeflow:
 	find ${PWD}/reads/ -name "reads_*.fa" > seq_dataset.lst
 	/usr/bin/time pg_run.py asm seq_dataset.lst 12 4 8 4 1 1 1 1 1 --with-consensus --output ./wd-pf
 
+test-pypeflow-with-L0:
+	rm -rf ./wd-pf
+	find ${PWD}/reads/ -name "reads_*.fa" > seq_dataset.lst
+	/usr/bin/time pg_run.py asm seq_dataset.lst 12 4 8 4 1 1 1 1 1 --with-L0-index --with-consensus --output ./wd-pf
+
+test-pypeflow-l1:
+	rm -rf ./wd-pf-l1
+	find ${PWD}/reads/ -name "reads_*.fa" > seq_dataset.lst
+	/usr/bin/time pg_run.py asm seq_dataset.lst 12 4 8 4 1 1 1 1 1 --shimmer-r 24 --with-consensus --shimmer-l 1 --output ./wd-pf-l1
+
 clean:
 	rm -rf ./wd/ ./logs/ ./reads/ seq_dataset.lst

--- a/docker/test/run_test.sh
+++ b/docker/test/run_test.sh
@@ -1,39 +1,13 @@
 #!/bin/bash
-set -e
-find $PWD/reads/ -name "reads_*.fa" > seq_dataset.lst
-WORKDIR=$PWD/wd
-INDEX=$WORKDIR/index
-OVLOUT=$WORKDIR/ovlp
-ASM=$WORKDIR/asm
-SHIMMER=../../..
-pushd $SHIMMER
-echo SHIMMER revision: $(git rev-parse HEAD)
-popd
-echo get SHIMMER binaries from $SHIMMER
-mkdir -p $INDEX
-mkdir -p $OVLOUT
-mkdir -p $ASM
-echo
-echo build read index
-time (/usr/bin/time shmr_mkseqdb -p $INDEX/seq_dataset -d seq_dataset.lst 2> build_db.log)
-echo
-echo build shimmer index
-time (for c in `seq 1 12`; do echo "/usr/bin/time shmr_index -p $INDEX/seq_dataset -t 12 -c $c -o $INDEX/shmr 2> build_index.$c.log" ; done | parallel -j 4)
-echo
-echo build overlaps
-time (for c in `seq -f "%02g" 1 8`; do echo "/usr/bin/time shmr_overlap -p $INDEX/seq_dataset -l $INDEX/shmr-L2 -t 8 -c $c -o $OVLOUT/ovlp.$c 2> ovlp.$c.log"; done | parallel -j 4)
-echo
-echo faclon ovlp to graph
-cd $ASM
-time (cat ../ovlp/ovlp.* | shmr_dedup > preads.ovl; echo "-" >> preads.ovl)
-/usr/bin/time ovlp_to_graph.py >& asm.log
-ln -sf ../index/seq_dataset.* .
-#/usr/bin/time pypy graph_to_contig.py >& to_contig.log
-/usr/bin/time graph_to_path.py >& to_path.log
-/usr/bin/time path_to_contig.py $INDEX/seq_dataset p_ctg_tiling_path > p_ctg.fa 2> to_contig.log
-echo $PWD/p_ctg.fa > p_ctg.lst
-time (/usr/bin/time shmr_mkseqdb -p $INDEX/p_ctg -d p_ctg.lst 2> build_p_ctg_db.log)
-time (for c in `seq 1 1`; do echo "/usr/bin/time shmr_index -p $INDEX/p_ctg -t 1 -c $c -o $INDEX/p_ctg 2> build_p_ctg_index.$c.log" ; done | parallel -j 4)
-time (/usr/bin/time shmr_map -r $INDEX/p_ctg -m $INDEX/p_ctg-L2 -p $INDEX/seq_dataset -l $INDEX/shmr-L2 -t 1 -c 1 > read_map.txt 2> map.log)
-time (/usr/bin/time cns_prototype.py $INDEX/seq_dataset $INDEX/p_ctg read_map.txt 1 1 > p_ctg_cns.fa 2> cns.log)
-
+make simreads
+make test-pypeflow
+if [ -d "/wd" ]; then
+    cp -a ./wd-pf/ /wd/ecoli_test_results/
+    cp K12MG1655.fa /wd/ecoli_test_results/
+    apt-get install -y mummer
+    cd /wd/ecoli_test_results/
+    dnadiff K12MG1655.fa p_ctg_cns.fa 
+    echo 
+    echo dnadiff output of the assembled contig to the e. coli genome used for the simulated reads
+    cat out.report
+fi

--- a/docker_dev/test/Makefile
+++ b/docker_dev/test/Makefile
@@ -10,24 +10,10 @@ simreads: K12MG1655.fa
 
 reads_0.fa: simreads
 
-test:
-	rm -rf ./wd ./logs
-	/usr/bin/time ./run_test.sh > all.log 2>&1;  mkdir -p logs;  mv *.log logs 
-
 test-pypeflow:
 	rm -rf ./wd-pf
 	find ${PWD}/reads/ -name "reads_*.fa" > seq_dataset.lst
 	/usr/bin/time pg_run.py asm seq_dataset.lst 12 4 8 4 1 1 1 1 1 --with-consensus --output ./wd-pf
-
-test-pypeflow-with-L0:
-	rm -rf ./wd-pf
-	find ${PWD}/reads/ -name "reads_*.fa" > seq_dataset.lst
-	/usr/bin/time pg_run.py asm seq_dataset.lst 12 4 8 4 1 1 1 1 1 --with-L0-index --with-consensus --output ./wd-pf
-
-test-pypeflow-l1:
-	rm -rf ./wd-pf-l1
-	find ${PWD}/reads/ -name "reads_*.fa" > seq_dataset.lst
-	/usr/bin/time pg_run.py asm seq_dataset.lst 12 4 8 4 1 1 1 1 1 --shimmer-r 24 --with-consensus --shimmer-l 1 --output ./wd-pf-l1
 
 clean:
 	rm -rf ./wd/ ./logs/ ./reads/ seq_dataset.lst

--- a/docker_dev/test/Makefile
+++ b/docker_dev/test/Makefile
@@ -19,5 +19,15 @@ test-pypeflow:
 	find ${PWD}/reads/ -name "reads_*.fa" > seq_dataset.lst
 	/usr/bin/time pg_run.py asm seq_dataset.lst 12 4 8 4 1 1 1 1 1 --with-consensus --output ./wd-pf
 
+test-pypeflow-with-L0:
+	rm -rf ./wd-pf
+	find ${PWD}/reads/ -name "reads_*.fa" > seq_dataset.lst
+	/usr/bin/time pg_run.py asm seq_dataset.lst 12 4 8 4 1 1 1 1 1 --with-L0-index --with-consensus --output ./wd-pf
+
+test-pypeflow-l1:
+	rm -rf ./wd-pf-l1
+	find ${PWD}/reads/ -name "reads_*.fa" > seq_dataset.lst
+	/usr/bin/time pg_run.py asm seq_dataset.lst 12 4 8 4 1 1 1 1 1 --shimmer-r 24 --with-consensus --shimmer-l 1 --output ./wd-pf-l1
+
 clean:
 	rm -rf ./wd/ ./logs/ ./reads/ seq_dataset.lst

--- a/docker_dev/test/run_test.sh
+++ b/docker_dev/test/run_test.sh
@@ -1,39 +1,13 @@
 #!/bin/bash
-set -e
-find $PWD/reads/ -name "reads_*.fa" > seq_dataset.lst
-WORKDIR=$PWD/wd
-INDEX=$WORKDIR/index
-OVLOUT=$WORKDIR/ovlp
-ASM=$WORKDIR/asm
-SHIMMER=../../..
-pushd $SHIMMER
-echo SHIMMER revision: $(git rev-parse HEAD)
-popd
-echo get SHIMMER binaries from $SHIMMER
-mkdir -p $INDEX
-mkdir -p $OVLOUT
-mkdir -p $ASM
-echo
-echo build read index
-time (/usr/bin/time shmr_mkseqdb -p $INDEX/seq_dataset -d seq_dataset.lst 2> build_db.log)
-echo
-echo build shimmer index
-time (for c in `seq 1 12`; do echo "/usr/bin/time shmr_index -p $INDEX/seq_dataset -t 12 -c $c -o $INDEX/shmr 2> build_index.$c.log" ; done | parallel -j 4)
-echo
-echo build overlaps
-time (for c in `seq -f "%02g" 1 8`; do echo "/usr/bin/time shmr_overlap -p $INDEX/seq_dataset -l $INDEX/shmr-L2 -t 8 -c $c -o $OVLOUT/ovlp.$c 2> ovlp.$c.log"; done | parallel -j 4)
-echo
-echo faclon ovlp to graph
-cd $ASM
-time (cat ../ovlp/ovlp.* | shmr_dedup > preads.ovl; echo "-" >> preads.ovl)
-/usr/bin/time ovlp_to_graph.py >& asm.log
-ln -sf ../index/seq_dataset.* .
-#/usr/bin/time pypy graph_to_contig.py >& to_contig.log
-/usr/bin/time graph_to_path.py >& to_path.log
-/usr/bin/time path_to_contig.py $INDEX/seq_dataset p_ctg_tiling_path > p_ctg.fa 2> to_contig.log
-echo $PWD/p_ctg.fa > p_ctg.lst
-time (/usr/bin/time shmr_mkseqdb -p $INDEX/p_ctg -d p_ctg.lst 2> build_p_ctg_db.log)
-time (for c in `seq 1 1`; do echo "/usr/bin/time shmr_index -p $INDEX/p_ctg -t 1 -c $c -o $INDEX/p_ctg 2> build_p_ctg_index.$c.log" ; done | parallel -j 4)
-time (/usr/bin/time shmr_map -r $INDEX/p_ctg -m $INDEX/p_ctg-L2 -p $INDEX/seq_dataset -l $INDEX/shmr-L2 -t 1 -c 1 > read_map.txt 2> map.log)
-time (/usr/bin/time cns_prototype.py $INDEX/seq_dataset $INDEX/p_ctg read_map.txt 1 1 > p_ctg_cns.fa 2> cns.log)
-
+make simreads
+make test-pypeflow
+if [ -d "/wd" ]; then
+    cp -a ./wd-pf/ /wd/ecoli_test_results/
+    cp K12MG1655.fa /wd/ecoli_test_results/
+    apt-get install -y mummer
+    cd /wd/ecoli_test_results/
+    dnadiff K12MG1655.fa p_ctg_cns.fa 
+    echo 
+    echo dnadiff output of the assembled contig to the e. coli genome used for the simulated reads
+    cat out.report
+fi


### PR DESCRIPTION
… Coli assembly

@sifta The is the PR for addressing Issue #5 for now.  

on a local docker image build, ` docker run -it --rm -v $PWD:/wd cschin/peregrine:$TAG test` works for now. I will looking DockerHub autobuild results too. 

We can move the E. coli reference URL to S3 later.