### PR TITLE
incorrect arrays allocated leading to null pointer

### DIFF
--- a/src/shmr_map.c
+++ b/src/shmr_map.c
@@ -244,7 +244,7 @@ int main(int argc, char *argv[]) {
 	}
 	
 	if (ref_shimmer_prefix == NULL) {
-		seqdb_prefix = (char *) calloc(8192, 1);
+		ref_shimmer_prefix = (char *) calloc(8192, 1);
 		snprintf( ref_shimmer_prefix, 8191, "ref-L2" );
 	}
 
@@ -254,7 +254,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	if (shimmer_prefix == NULL) {
-		seqdb_prefix = (char *) calloc(8192, 1);
+		shimmer_prefix = (char *) calloc(8192, 1);
 		snprintf( shimmer_prefix, 8191, "shimmer-L2" );
 	}
 


### PR DESCRIPTION
This was causing a crash on my run, I think the names should match the if check above in each block.